### PR TITLE
Simplify `UartAddress` impl + better docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  # Enable crate version updates for the main crate
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  # Enable version updates for Github Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/check-and-lint.yaml
+++ b/.github/workflows/check-and-lint.yaml
@@ -1,0 +1,39 @@
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+name: Check and Lint
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          components: rust-src
+          profile: minimal
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  rustfmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          components: rustfmt
+          profile: minimal
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ description = "A clean implementation of the UART_16550 device functionality."
 
 [dependencies]
 bitflags = "2.9.1"
-safe-mmio = "0.2.5"
 
 [features]
 default = ["address_impl", "writer_impl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uart"
-version = "2.1.1"
+version = "3.0.0"
 edition = "2024"
 license = "BSD-3-Clause"
 repository = "https://github.com/linuiz-project/uart"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ description = "A clean implementation of the UART_16550 device functionality."
 
 [dependencies]
 bitflags = "2.9.1"
+safe-mmio = "0.2.5"
 
 [features]
 default = ["address_impl", "writer_impl"]

--- a/src/address.rs
+++ b/src/address.rs
@@ -8,7 +8,7 @@ pub struct PortAddress(NonZero<u16>);
 impl PortAddress {
     /// Creates a new [`PortAddress`] with `base` as the base port address.
     ///
-    /// ## Safety
+    /// # Safety
     ///
     /// - Base address must be a port-based UART device.
     pub const unsafe fn new(base: NonZero<u16>) -> Self {
@@ -23,6 +23,7 @@ unsafe impl UartAddress for PortAddress {
         let port_address = self.0.checked_add(register as u16).unwrap();
         let value: u8;
 
+        // Safety: Caller is required to ensure that reading from port `port_address` is valid.
         #[cfg(target_arch = "x86_64")]
         unsafe {
             core::arch::asm!(
@@ -42,6 +43,7 @@ unsafe impl UartAddress for PortAddress {
     unsafe fn write(&self, register: WriteableRegister, value: u8) {
         let port_address = self.0.checked_add(register as u16).unwrap();
 
+        // Safety: Caller is required to ensure that writing `value` to port `port_address` is valid.
         #[cfg(target_arch = "x86_64")]
         unsafe {
             core::arch::asm!(
@@ -66,7 +68,7 @@ pub struct MmioAddress {
 impl MmioAddress {
     /// Creates a new [`MmioAddress`] with `base` as the base memory address.
     ///
-    /// ## Safety
+    /// # Safety
     ///
     /// - `base` must be a pointer to an MMIO-based UART device.
     /// - `stride` must be the uniform distance (in bytes) between each UART register.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,27 +248,59 @@ bitflags! {
     }
 }
 
-/// The read-enabled UART registers and their order.
-#[repr(u16)]
+/// The read-enabled UART registers and their offset index.
 #[derive(Debug, Clone, Copy)]
 pub enum ReadableRegister {
-    ReceiverHolding = 0x0,
-    InterruptEnable = 0x1,
-    InterruptStatus = 0x2,
-    LineControl = 0x3,
-    LineStatus = 0x5,
-    ModemStatus = 0x6,
+    ReceiverHolding,
+    InterruptEnable,
+    InterruptStatus,
+    LineControl,
+    LineStatus,
+    ModemStatus,
+
+    DivisorLatchLow,
+    DivisorLatchHigh,
 }
 
-/// The write-enabled UART registers and their order.
+impl ReadableRegister {
+    /// Offset index of the provided [`ReadableRegister`].
+    pub const fn as_index(self) -> u16 {
+        match self {
+            ReadableRegister::ReceiverHolding | ReadableRegister::DivisorLatchLow => 0x0,
+            ReadableRegister::InterruptEnable | ReadableRegister::DivisorLatchHigh => 0x1,
+            ReadableRegister::InterruptStatus => 0x2,
+            ReadableRegister::LineControl => 0x3,
+            ReadableRegister::LineStatus => 0x5,
+            ReadableRegister::ModemStatus => 0x6,
+        }
+    }
+}
+
+/// The write-enabled UART registers and their offset index.
 #[repr(u16)]
 #[derive(Debug, Clone, Copy)]
 pub enum WriteableRegister {
-    TransmitterHolding = 0x0,
-    InterruptEnable = 0x1,
-    FifoControl = 0x2,
-    LineControl = 0x3,
-    ModemControl = 0x4,
+    TransmitterHolding,
+    InterruptEnable,
+    FifoControl,
+    LineControl,
+    ModemControl,
+
+    DivisorLatchLow,
+    DivisorLatchHigh,
+}
+
+impl WriteableRegister {
+    /// Offset index of the provided [`WriteableRegister`].
+    pub const fn as_index(self) -> u16 {
+        match self {
+            WriteableRegister::TransmitterHolding | WriteableRegister::DivisorLatchLow => 0x0,
+            WriteableRegister::InterruptEnable | WriteableRegister::DivisorLatchHigh => 0x1,
+            WriteableRegister::FifoControl => 0x2,
+            WriteableRegister::LineControl => 0x3,
+            WriteableRegister::ModemControl => 0x4,
+        }
+    }
 }
 
 /// Represents an address type for a UART device, allowing idiomatic access to register
@@ -277,11 +309,26 @@ pub enum WriteableRegister {
 ///
 /// # Safety
 ///
-/// - The type may only be constructed only with a valid UART base address.
-/// - Ensure returned addresses are valid to read or write the register
-///   passed in [`UartAddress::get_read_address`] or [`UartAddress::get_write_address`].
+/// - The type implementing this trait should only be constructed with a valid UART base
+///   address (this may be a safety invariant on an `unsafe fn` constructor).
 pub unsafe trait UartAddress {
+    /// Writes `value` to `register`.
+    ///
+    /// # Safety
+    ///
+    /// - Writing `value` to the provided `register` has the potential to change
+    ///   the value of other registers. For instance, writing [`FifoControl::CLEAR_TX`] will
+    ///   change the contents of (in this case, zero out) [`WriteableRegister::TransmitterHolding`].
     unsafe fn write(&self, register: WriteableRegister, value: u8);
+
+    /// Reads a raw [`u8`] from `register`.
+    ///
+    /// # Safety
+    ///
+    /// - Reading a value from certain registers will affect the contents of others.
+    ///   For instance, reading the line status will always clear the [`InterruptStatus::INTERRUPT_PENDING`] bit.
+    ///   Because of this, any calling context that passes [`ReadableRegister::LineStatus`] should be `&mut self`, or
+    ///   otherwise exclusively alias the address that is being read from.
     unsafe fn read(&self, register: ReadableRegister) -> u8;
 }
 
@@ -304,13 +351,15 @@ pub struct Uart<A: UartAddress, M: Mode> {
 impl<A: UartAddress, M: Mode> Uart<A, M> {
     /// Read from the interrupt status register.
     pub fn read_interrupt_status(&self) -> InterruptStatus {
+        // Safety: Reading the interrupt status register has no side effects, so `self` is immutably aliased.
         let value = unsafe { self.base_address.read(ReadableRegister::InterruptStatus) };
 
         InterruptStatus::from_bits_retain(value)
     }
 
     /// Write to the FIFO control register.
-    pub unsafe fn write_fifo_control(&mut self, fifo_control: FifoControl) {
+    pub fn write_fifo_control(&mut self, fifo_control: FifoControl) {
+        // Safety: Writing the FIFO control register has side effects, so `self` is mutably aliased.
         unsafe {
             self.base_address
                 .write(WriteableRegister::FifoControl, fifo_control.bits());
@@ -319,6 +368,7 @@ impl<A: UartAddress, M: Mode> Uart<A, M> {
 
     /// Read from the line control register.
     pub fn read_line_control(&self) -> LineControl {
+        // Safety: Reading the line control register has no side effects, so `self` is immutably aliased.
         let value = unsafe { self.base_address.read(ReadableRegister::LineControl) };
 
         // Safety: `self.read(...)` returns a single byte, of which `LineControl` uses all bits (so no unknown bits are possible).
@@ -326,7 +376,8 @@ impl<A: UartAddress, M: Mode> Uart<A, M> {
     }
 
     /// Write to the line control register.
-    pub unsafe fn write_line_control(&mut self, value: LineControl) {
+    pub fn write_line_control(&mut self, value: LineControl) {
+        // Safety: Writing the line control register has side effects, so `self` is mutably aliased.
         unsafe {
             self.base_address
                 .write(WriteableRegister::LineControl, value.bits());
@@ -334,7 +385,8 @@ impl<A: UartAddress, M: Mode> Uart<A, M> {
     }
 
     /// Write to the modem control register.
-    pub unsafe fn write_modem_control(&mut self, value: ModemControl) {
+    pub fn write_modem_control(&mut self, value: ModemControl) {
+        // Safety: Writing the modem control register has side effects, so `self` is mutably aliased.
         unsafe {
             self.base_address
                 .write(WriteableRegister::ModemControl, value.bits());
@@ -342,7 +394,8 @@ impl<A: UartAddress, M: Mode> Uart<A, M> {
     }
 
     /// Read from the line status register.
-    pub unsafe fn read_line_status(&mut self) -> LineStatus {
+    pub fn read_line_status(&mut self) -> LineStatus {
+        // Safety: Reading the line status register has side effects, so `self` is mutably aliased.
         let value = unsafe { self.base_address.read(ReadableRegister::LineStatus) };
 
         LineStatus::from_bits_retain(value)
@@ -350,6 +403,7 @@ impl<A: UartAddress, M: Mode> Uart<A, M> {
 
     /// Read from the modem status register.
     pub fn read_modem_status(&self) -> ModemStatus {
+        // Safety: Reading the modem status register has no side effects, so `self` is immutably aliased.
         let value = unsafe { self.base_address.read(ReadableRegister::ModemStatus) };
 
         ModemStatus::from_bits_retain(value)
@@ -357,6 +411,8 @@ impl<A: UartAddress, M: Mode> Uart<A, M> {
 }
 
 impl<A: UartAddress> Uart<A, DLAB> {
+    /// Creates a new [`Uart`] pointing to `base_address`.
+    ///
     /// # Safety
     ///
     /// - Provided address must be valid as the base address of a UART device.
@@ -371,9 +427,9 @@ impl<A: UartAddress> Uart<A, DLAB> {
 
     /// Read from the divisor latch from the 1st & 2nd registers.
     fn read_divisor_latch(&self) -> u16 {
-        // When DLAB is enabled, RHR and IER become the LSB and MSB of the
-        // divisor latch register, respectively.
+        // When DLAB is enabled, offset index 1 and 2 become the least- and most- significant bits of the divisor latch, respectively.
 
+        // Safety: While in DLAB mode, there are no side effects to reading the divisor latch registers, so `self` is immutably aliased.
         unsafe {
             let lsb = u16::from(self.base_address.read(ReadableRegister::ReceiverHolding));
             let msb = u16::from(self.base_address.read(ReadableRegister::InterruptEnable));
@@ -384,11 +440,11 @@ impl<A: UartAddress> Uart<A, DLAB> {
 
     /// Write the divisor latch to the 1st & 2nd registers.
     fn write_divisor_latch(&mut self, value: u16) {
-        // When DLAB is enabled, THR and IER become the LSB and MSB of the
-        // divisor latch register, respectively.
+        // When DLAB is enabled, offset index 1 and 2 become the least- and most- significant bits of the divisor latch, respectively.
 
         let value_le_bytes = value.to_le_bytes();
 
+        // Safety: Writing to the divisor latch registers  While in DLAB mode, there are no side effects to reading the divisor latch registers, so `self` is immutably aliased.
         unsafe {
             self.base_address
                 .write(WriteableRegister::TransmitterHolding, value_le_bytes[0]);
@@ -424,6 +480,7 @@ impl<A: UartAddress> Uart<A, DLAB> {
         let mut line_control = self.read_line_control();
         line_control.remove(LineControl::DLAB);
 
+        // Safety: Unsetting the DLAB bit has side effects, so `self` is mutably aliased.
         unsafe {
             self.base_address
                 .write(WriteableRegister::LineControl, line_control.bits());
@@ -437,11 +494,11 @@ impl<A: UartAddress> Uart<A, DLAB> {
 }
 
 impl<A: UartAddress> Uart<A, Data> {
+    /// Creates a new [`Uart`] pointing to `base_address`.
+    ///
     /// # Safety
     ///
-    /// - Provided address must be valid as the base address of a UART device.
-    /// - Provided address must not be otherwise mutably aliased.
-    /// - Device must have bit 7 of the line control register (DLAB enable) set to 0.
+    /// - UART must have bit 7 of the line control register (DLAB enable) set to 0.
     pub unsafe fn new(base_address: A) -> Self {
         Self {
             base_address,
@@ -449,13 +506,27 @@ impl<A: UartAddress> Uart<A, Data> {
         }
     }
 
-    /// Reads a byte from the 1st register (RHR).
+    /// Creates a new [`Uart`] pointing to `base_address`, and resets all the control and holding registers.
+    pub fn new_reset(base_address: A) -> Self {
+        // Safety: We're going to reset the device, so we don't care if it's correct or not.
+        let mut uart = unsafe { Self::new(base_address) };
+
+        uart.write_fifo_control(FifoControl::CLEAR_RX | FifoControl::CLEAR_TX);
+        uart.write_line_control(LineControl::empty());
+        uart.write_modem_control(ModemControl::empty());
+
+        uart
+    }
+
+    /// Reads a byte from the receiver holding register.
     pub fn read_byte(&mut self) -> u8 {
+        // Safety: Reading from the receiver holding register clears it, so `self` is mutably aliased.
         unsafe { self.base_address.read(ReadableRegister::ReceiverHolding) }
     }
 
-    /// Writes a byte to the 2nd register (THR).
+    /// Writes a byte to the transmitter holding register
     pub fn write_byte(&mut self, byte: u8) {
+        // Safety: Writing to the transmitter holding register sets it, so `self` is mutably aliased.
         unsafe {
             self.base_address
                 .write(WriteableRegister::TransmitterHolding, byte);
@@ -464,6 +535,7 @@ impl<A: UartAddress> Uart<A, Data> {
 
     /// Reads from the interrupt enable register.
     pub fn read_interrupt_enable(&self) -> InterruptEnable {
+        // Safety: Reading the interrupt enable register has no side effects, so `self` is immutably aliased.
         let value = unsafe { self.base_address.read(ReadableRegister::InterruptEnable) };
 
         InterruptEnable::from_bits_retain(value)
@@ -471,6 +543,7 @@ impl<A: UartAddress> Uart<A, Data> {
 
     /// Writes to the interrupt enable register.
     pub fn write_interrupt_enable(&mut self, value: InterruptEnable) {
+        // Safety: Writing the interrupt enable register has side effects, so `self` is mutably aliased.
         unsafe {
             self.base_address
                 .write(WriteableRegister::InterruptEnable, value.bits());
@@ -482,6 +555,7 @@ impl<A: UartAddress> Uart<A, Data> {
         let mut line_control = self.read_line_control();
         line_control.insert(LineControl::DLAB);
 
+        // Safety: Setting the DLAB bit has side effects, so `self` is mutably aliased.
         unsafe {
             self.base_address
                 .write(WriteableRegister::LineControl, line_control.bits());

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -71,7 +71,9 @@ impl<A: UartAddress> core::fmt::Write for UartWriter<A> {
     }
 
     fn write_char(&mut self, c: char) -> core::fmt::Result {
-        while !self.0.read_line_status().contains(LineStatus::THR_EMPTY) {
+        // Safety: UART is not configured to have interrupts enabled, so cannot accidentally
+        //         clear the interrupt status register.
+        while !(unsafe { self.0.read_line_status() }).contains(LineStatus::THR_EMPTY) {
             core::hint::spin_loop();
         }
 


### PR DESCRIPTION
This PR will simplify (internally) the implementation of the `crate::UartAddress` trait.

Additionally, the documentation has been updated to be more consistent throughout, as well as more informative of safety considerations.