### PR TITLE
Remove `as` keyword usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uart"
-version = "3.0.0"
+version = "3.0.1"
 edition = "2024"
 license = "BSD-3-Clause"
 repository = "https://github.com/linuiz-project/uart"

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ impl<A: UartAddress> core::fmt::Write for UartWriter<A> {
 
         self.0.write_byte({
             // We can practically only write ASCII to a UART, so replace
-            // any char that isn't with a question mark.
+            // any char that isn't ASCII with a question mark.
             if c.is_ascii() { c as u8 } else { b'?' }
         });
 
@@ -99,15 +99,15 @@ Notably, the above implementation is I/O-agnostic, and uses the crate features t
 use crate::{ReadableRegister, RegisterAddress, UartAddress, WriteableRegister};
 
 /// A port-based UART address.
-pub struct PortAddress(u16);
+pub struct PortAddress(NonZero<u16>);
 
 impl PortAddress {
-    /// Creates a new [`PortAddress`].
+    /// Creates a new [`PortAddress`] with `base` as the base port address.
     ///
-    /// ## Safety
+    /// # Safety
     ///
-    /// - `base` must be the base address of a port-based UART device.
-    pub const unsafe fn new(base: u16) -> Self {
+    /// - Base address must be a port-based UART device.
+    pub const unsafe fn new(base: NonZero<u16>) -> Self {
         Self(base)
     }
 }
@@ -115,12 +115,43 @@ impl PortAddress {
 // Safety: Constructor requires that the base address be valid, and register
 //         impls are correctly offset from that.
 unsafe impl UartAddress for PortAddress {
-    fn get_read_address(&self, register: ReadableRegister) -> RegisterAddress {
-        RegisterAddress::Port(self.0 + (register as u16))
+    unsafe fn read(&self, register: ReadableRegister) -> u8 {
+        let port_address = self.0.checked_add(register.as_index()).unwrap();
+        let value: u8;
+
+        // Safety: Caller is required to ensure that reading from port `port_address` is valid.
+        #[cfg(target_arch = "x86_64")]
+        unsafe {
+            core::arch::asm!(
+                "in al, dx",
+                out("al") value,
+                in("dx") port_address.get(),
+                options(nostack, nomem, preserves_flags)
+            );
+        }
+
+        #[cfg(not(target_arch = "x86_64"))]
+        unimplemented!();
+
+        value
     }
 
-    fn get_write_address(&self, register: WriteableRegister) -> RegisterAddress {
-        RegisterAddress::Port(self.0 + (register as u16))
+    unsafe fn write(&self, register: WriteableRegister, value: u8) {
+        let port_address = self.0.checked_add(register.as_index()).unwrap();
+
+        // Safety: Caller is required to ensure that writing `value` to port `port_address` is valid.
+        #[cfg(target_arch = "x86_64")]
+        unsafe {
+            core::arch::asm!(
+                "out dx, al",
+                in("dx") port_address.get(),
+                in("al") value,
+                options(nostack, nomem, preserves_flags)
+            );
+        }
+
+        #[cfg(not(target_arch = "x86_64"))]
+        unimplemented!();
     }
 }
 ```
@@ -134,19 +165,18 @@ use crate::{ReadableRegister, RegisterAddress, UartAddress, WriteableRegister};
 
 /// An MMIO-based UART address.
 pub struct MmioAddress {
-    base: *mut u8,
+    base: NonNull<u8>,
     stride: usize,
 }
 
 impl MmioAddress {
-    /// Creates a new [`MmioAddress`].
+    /// Creates a new [`MmioAddress`] with `base` as the base memory address.
     ///
-    /// ## Safety
+    /// # Safety
     ///
-    /// - `base` must be the base address of an MMIO-based UART device.
-    /// - `stride` must be the uniform distance (in bytes) between each
-    ///   UART register.
-    pub const unsafe fn new(base: *mut u8, stride: usize) -> Self {
+    /// - `base` must be a pointer to an MMIO-based UART device.
+    /// - `stride` must be the uniform distance (in bytes) between each UART register.
+    pub const unsafe fn new(base: NonNull<u8>, stride: usize) -> Self {
         Self { base, stride }
     }
 }
@@ -154,24 +184,28 @@ impl MmioAddress {
 // Safety: Constructor requires that the base address be valid, and register
 //         impls are correctly offset from that.
 unsafe impl UartAddress for MmioAddress {
-    fn get_read_address(&self, register: ReadableRegister) -> RegisterAddress {
-        RegisterAddress::Mmio({
-            // Safety: `self.base` is required to be a valid base address,
-            //         `register` is a valid offset, and `self.stride` is
-            //         required to be the distance (in bytes) between each
-            //         UART register.
-            unsafe { self.base.add((register as usize) * self.stride) }
-        })
+    unsafe fn write(&self, register: WriteableRegister, value: u8) {
+        // Safety: - `self.base` is required to be a valid base address.
+        //         - `register` is a valid offset.
+        //         - `self.stride` is required to be the distance (in bytes) between each UART register.
+        //         - Writing `value` is required to not cause undefined behaviour.
+        unsafe {
+            self.base
+                .byte_add(usize::from(register.as_index()) * self.stride)
+                .write_volatile(value);
+        }
     }
 
-    fn get_write_address(&self, register: WriteableRegister) -> RegisterAddress {
-        RegisterAddress::Mmio({
-            // Safety: `self.base` is required to be a valid base address,
-            //         `register` is a valid offset, and `self.stride` is
-            //         required to be the distance (in bytes) between each
-            //         UART register.
-            unsafe { self.base.add((register as usize) * self.stride) }
-        })
+    unsafe fn read(&self, register: ReadableRegister) -> u8 {
+        // Safety: - `self.base` is required to be a valid base address.
+        //         - `register` is a valid offset.
+        //         - `self.stride` is required to be the distance (in bytes) between each UART register.
+        //         - Reading `value` is required to not cause undefined behaviour.
+        unsafe {
+            self.base
+                .byte_add(usize::from(register.as_index()) * self.stride)
+                .read_volatile()
+        }
     }
 }
 

--- a/src/address.rs
+++ b/src/address.rs
@@ -20,7 +20,7 @@ impl PortAddress {
 //         impls are correctly offset from that.
 unsafe impl UartAddress for PortAddress {
     unsafe fn read(&self, register: ReadableRegister) -> u8 {
-        let port_address = self.0.checked_add(register as u16).unwrap();
+        let port_address = self.0.checked_add(register.as_index()).unwrap();
         let value: u8;
 
         // Safety: Caller is required to ensure that reading from port `port_address` is valid.
@@ -41,7 +41,7 @@ unsafe impl UartAddress for PortAddress {
     }
 
     unsafe fn write(&self, register: WriteableRegister, value: u8) {
-        let port_address = self.0.checked_add(register as u16).unwrap();
+        let port_address = self.0.checked_add(register.as_index()).unwrap();
 
         // Safety: Caller is required to ensure that writing `value` to port `port_address` is valid.
         #[cfg(target_arch = "x86_64")]
@@ -87,7 +87,7 @@ unsafe impl UartAddress for MmioAddress {
         //         - Writing `value` is required to not cause undefined behaviour.
         unsafe {
             self.base
-                .byte_add((register as usize) * self.stride)
+                .byte_add(usize::from(register.as_index()) * self.stride)
                 .write_volatile(value);
         }
     }
@@ -99,7 +99,7 @@ unsafe impl UartAddress for MmioAddress {
         //         - Reading `value` is required to not cause undefined behaviour.
         unsafe {
             self.base
-                .byte_add((register as usize) * self.stride)
+                .byte_add(usize::from(register.as_index()) * self.stride)
                 .read_volatile()
         }
     }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -71,9 +71,7 @@ impl<A: UartAddress> core::fmt::Write for UartWriter<A> {
     }
 
     fn write_char(&mut self, c: char) -> core::fmt::Result {
-        // Safety: UART is not configured to have interrupts enabled, so cannot accidentally
-        //         clear the interrupt status register.
-        while !(unsafe { self.0.read_line_status() }).contains(LineStatus::THR_EMPTY) {
+        while !self.0.read_line_status().contains(LineStatus::THR_EMPTY) {
             core::hint::spin_loop();
         }
 


### PR DESCRIPTION
Casual use of the `as` keyword caused an issue with both the `crate::WriteableRegister` and `crate::ReadableRegister` enums when being used in the `crate::address::` implementation types, whereby the enums were being implicitly cast to reprs that were no longer meaningful in that context.

In an abundance of caution, usage of the `as` keyword has been removed crate-wide, namely in the usage of the `Baud` enum.